### PR TITLE
sync version number with npmjs.org

### DIFF
--- a/tasks/nginx/site/package.json
+++ b/tasks/nginx/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtuple-server-nginx-site",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "xTuple Server Task [nginx.site]: create the nginx site file for a new xTuple instance deployment",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
xtuple-server-nginx-site v1.0.3 was published aug 2014 but the version number on master wasn't updated. unclear how this happened.