### PR TITLE
Output database names after install.

### DIFF
--- a/tasks/pg/cluster/index.js
+++ b/tasks/pg/cluster/index.js
@@ -53,6 +53,7 @@ _.extend(exports, lib.task, /** @exports cluster */ {
       options.report['Postgres Instance'] = {
         'Cluster Name': options.pg.cluster.name,
         'Port Number': options.pg.cluster.port,
+        'Database Names': _.pluck(options.xt.database.list, 'dbname').join(', '),
       };
     }
   },


### PR DESCRIPTION
Adding a line to the final output of an install plan listing the databases.